### PR TITLE
Support to populate NBFT for failed cases

### DIFF
--- a/lib/nvme/nvme_internal.h
+++ b/lib/nvme/nvme_internal.h
@@ -848,6 +848,13 @@ struct spdk_nvme_probe_ctx {
 	TAILQ_HEAD(, spdk_nvme_ctrlr)		init_ctrlrs;
 };
 
+struct spdk_nvme_fail_trid {
+	struct spdk_nvme_transport_id  trid;
+	LIST_ENTRY                     link;
+};
+extern LIST_ENTRY                   fail_conn;
+void nvme_fabric_insert_fail_trid(struct spdk_nvme_transport_id* trid);
+
 typedef void (*nvme_ctrlr_detach_cb)(struct spdk_nvme_ctrlr *ctrlr);
 
 struct nvme_ctrlr_detach_ctx {


### PR DESCRIPTION
This change is to populate the details of failed connections to NBFT. This applies to such subsystems, for which attempt has been configured but the NVMe-oF driver was unable to create a successful connection to them. This change will enable the booting OS to get the details of such subsystems from NBFT and retry the connection to proceed with booting from them.